### PR TITLE
add support for updated classification names

### DIFF
--- a/caper/caper/StackedBarChart.py
+++ b/caper/caper/StackedBarChart.py
@@ -4,8 +4,18 @@ import plotly.express as px
 
 def StackedBarChart(sample):
     start_time = time.time()
+
+    fa_cmap = {
+                'ecDNA': "rgb(255, 0, 0)",
+                'BFB': 'rgb(0, 70, 46)',
+                'Complex non-cyclic': 'rgb(255, 190, 0)',
+                'Linear amplification': 'rgb(27, 111, 185)',
+                'Complex-non-cyclic': 'rgb(255, 190, 0)',
+                'Linear': 'rgb(27, 111, 185)'
+                }
+
     df = pd.DataFrame(sample)
-    classes = ['ecDNA', 'BFB', 'Complex non-cyclic', 'Linear amplification']
+    classes = ['ecDNA', 'BFB', 'Complex non-cyclic', 'Complex-non-cyclic', 'Linear amplification', 'Linear']
 
     seen_classes = set(df['Classification'])
     if None in seen_classes:
@@ -21,30 +31,23 @@ def StackedBarChart(sample):
         df2.loc[len(df2)] = [x, "Linear amplification", 0]
 
     output = df2.pivot(index='Sample_name', columns='Classification', values='Count')
-    df = output.sort_values(classes, ascending=[False, False, False, False])
+    df = output.sort_values(classes, ascending=[False, False, False, False, False, False])
     df2 = df.reset_index()
     df2['Sample_name'] = df2['Sample_name'].apply(lambda x: x[0:10] + "..." if len(x) > 10 else x)
 
     if len(df2['Sample_name']) < 10:
         fig = px.bar(df2, x="Sample_name", y = classes,
                 barmode = 'stack',
-                 color_discrete_map = {
-                        'ecDNA' : "rgb(255, 0, 0)",
-                        'BFB' : 'rgb(0, 70, 46)',
-                        'Complex non-cyclic' : 'rgb(255, 190, 0)',
-                        'Linear amplification' : 'rgb(27, 111, 185)'},
-                 hover_data = {'Sample_name': False})
+                 color_discrete_map = fa_cmap,
+                 hover_data={'Sample_name': False})
     else:
         fig = px.bar(data_frame = df2, x="Sample_name", y = classes,
                 barmode = 'stack',
-                 color_discrete_map = {
-                        'ecDNA' : "rgb(255, 0, 0)",
-                        'BFB' : 'rgb(0, 70, 46)',
-                        'Complex non-cyclic' : 'rgb(255, 190, 0)',
-                        'Linear amplification' : 'rgb(27, 111, 185)'},
+                 color_discrete_map = fa_cmap,
                  hover_data = {'Sample_name': False}, range_x=([-0.5, 24]))
 
-    fig.update_xaxes(tickangle=60, automargin=True, tickfont=dict(size=10), gridcolor = 'white', rangeslider_visible=True, tickprefix = "   ")
+    fig.update_xaxes(tickangle=60, automargin=True, tickfont=dict(size=10), gridcolor = 'white',
+                     rangeslider_visible=True, tickprefix = "   ")
     fig.update_yaxes(gridcolor = 'white', rangemode='tozero', ticks = 'outside') ## ADD Y TICKS
     fig.update_layout(showlegend=False, plot_bgcolor = 'white')
     fig.update_layout(yaxis_title="Number of focal amps")

--- a/caper/caper/StackedBarChart.py
+++ b/caper/caper/StackedBarChart.py
@@ -2,18 +2,8 @@ import time
 import pandas as pd
 import plotly.express as px
 
-def StackedBarChart(sample):
+def StackedBarChart(sample, fa_cmap):
     start_time = time.time()
-
-    fa_cmap = {
-                'ecDNA': "rgb(255, 0, 0)",
-                'BFB': 'rgb(0, 70, 46)',
-                'Complex non-cyclic': 'rgb(255, 190, 0)',
-                'Linear amplification': 'rgb(27, 111, 185)',
-                'Complex-non-cyclic': 'rgb(255, 190, 0)',
-                'Linear': 'rgb(27, 111, 185)'
-                }
-
     df = pd.DataFrame(sample)
     classes = ['ecDNA', 'BFB', 'Complex non-cyclic', 'Complex-non-cyclic', 'Linear amplification', 'Linear']
 

--- a/caper/caper/StackedBarChart.py
+++ b/caper/caper/StackedBarChart.py
@@ -6,8 +6,8 @@ import plotly.express as px
 def StackedBarChart(sample, fa_cmap):
     start_time = time.time()
     df = pd.DataFrame(sample)
-    corder = {'ecDNA':0, 'BFB': 1, 'Complex-non-cyclic':2, 'Complex non-cyclic':3, 'Linear amplification':4, 'Linear':5}
-    classes = ['ecDNA', 'BFB', 'Complex non-cyclic', 'Complex-non-cyclic', 'Linear amplification', 'Linear']
+    corder = {'ecDNA':0, 'BFB': 1, 'Complex-non-cyclic':2, 'Complex non-cyclic':3, 'Linear amplification':4, 'Linear':5, 'None':6}
+    classes = ['ecDNA', 'BFB', 'Complex non-cyclic', 'Complex-non-cyclic', 'Linear amplification', 'Linear', 'None']
 
     seen_classes = set(df['Classification'])
     if None in seen_classes:
@@ -20,40 +20,29 @@ def StackedBarChart(sample, fa_cmap):
         df2.loc[len(df2)] = [df2['Sample_name'][0], x, 0]
 
     for x in none_samps:
-        df2.loc[len(df2)] = [x, "Linear amplification", 0]
+        df2.loc[len(df2)] = [x, "None", 0]
 
     class_count_per_sample = defaultdict(lambda: defaultdict(int))
     for _, row in df2.iterrows():
         class_count_per_sample[row['Sample_name']][row['Classification']] = row['Count']
 
+    # df2['Sample_name_trunc'] = df2['Sample_name'].apply(lambda x: x[0:10] + "..." if len(x) > 10 else x)
     cc_tuples = {x: [-y[c] for c in classes] for x, y in class_count_per_sample.items()}
     sort_col = [(corder[row['Classification']], cc_tuples[row['Sample_name']], row['Sample_name']) for _, row in df2.iterrows()]
     df2['sort_order_col'] = sort_col
-
     df2.sort_values(inplace=True, by=['sort_order_col'])
-    #output = df2.pivot(index='Sample_name', columns='Classification', values='Count')
-    #df = output.sort_values(classes, ascending=[False, False, False, False])
-    # df2 = df.reset_index()
-    df2['Sample_name_trunc'] = df2['Sample_name'].apply(lambda x: x[0:10] + "..." if len(x) > 10 else x)
+    print(df2)
 
     if len(df2['Sample_name']) < 10:
         fig = px.bar(df2, x="Sample_name", y = "Count", color='Classification',
                 barmode = 'stack', custom_data=["Sample_name", "Classification"],
-                color_discrete_map = {
-                        'ecDNA' : "rgb(255, 0, 0)",
-                        'BFB' : 'rgb(0, 70, 46)',
-                        'Complex non-cyclic' : 'rgb(255, 190, 0)',
-                        'Linear amplification' : 'rgb(27, 111, 185)'},
-                )
+                color_discrete_map = fa_cmap,
+            )
     else:
         fig = px.bar(df2, x="Sample_name", y = "Count", color='Classification',
                 barmode = 'stack', custom_data=["Sample_name", "Classification"], range_x=([-0.5, 24]),
-                color_discrete_map = {
-                        'ecDNA' : "rgb(255, 0, 0)",
-                        'BFB' : 'rgb(0, 70, 46)',
-                        'Complex non-cyclic' : 'rgb(255, 190, 0)',
-                        'Linear amplification' : 'rgb(27, 111, 185)'},
-                )
+                color_discrete_map = fa_cmap,
+            )
 
     showslider = True if len(df2['Sample_name']) > 24 else False
     fig.update_xaxes(tickangle=60, automargin=True, tickfont=dict(size=10), gridcolor = 'white',
@@ -65,12 +54,14 @@ def StackedBarChart(sample, fa_cmap):
                       "Count: %{y}<br>" +
                       "<extra></extra>",
                       )
+    ordered_name_set = df2['Sample_name'].unique()
+    trunc_names = [x[0:10] + "..." if len(x) > 10 else x for x in ordered_name_set]
     fig.update_layout(showlegend=False, plot_bgcolor = 'white', yaxis_title="Number of focal amps", xaxis_title=None,
                       height=400, margin={'t': 20, 'b': 0, 'r': 0, 'l': 20},
                       xaxis={
                         'tickmode': 'array',
                         'tickvals': list(range(len(df2['Sample_name']))),
-                        'ticktext': df2['Sample_name_trunc'].tolist(),
+                        'ticktext': trunc_names,
                       },
     )
 

--- a/caper/caper/classification.py
+++ b/caper/caper/classification.py
@@ -7,9 +7,11 @@ def pie_chart(sample):
     class_counts = df['Classification'].value_counts()
     color_scale_map = {
         'ecDNA': '#FF4343',
-        'Complex non-cyclic' : '#FFBE00' , 
+        'Complex non-cyclic': '#FFBE00',
         'BFB' :'#00462E', 
-        'Linear amplification': '#1B6FB9'
+        'Linear amplification': '#1B6FB9',
+        'Complex-non-cyclic': '#FFBE00',
+        'Linear': '#1B6FB9'
     }
     fig = px.pie(class_counts, values='Classification', color=class_counts.index, names=class_counts.axes[0].tolist(),
                  color_discrete_map= color_scale_map)

--- a/caper/caper/project_pie_chart.py
+++ b/caper/caper/project_pie_chart.py
@@ -1,20 +1,20 @@
 import pandas as pd
 import plotly.express as px
 
-def pie_chart(sample):
+def pie_chart(sample, fa_cmap):
     df = pd.DataFrame(sample)
 
     class_counts = df['Classification'].value_counts()
-    color_scale_map = {
-        'ecDNA': '#FF4343',
-        'Complex non-cyclic': '#FFBE00',
-        'BFB' :'#00462E', 
-        'Linear amplification': '#1B6FB9',
-        'Complex-non-cyclic': '#FFBE00',
-        'Linear': '#1B6FB9'
-    }
+    # color_scale_map = {
+    #     'ecDNA': '#FF4343',
+    #     'Complex non-cyclic': '#FFBE00',
+    #     'BFB' :'#00462E',
+    #     'Linear amplification': '#1B6FB9',
+    #     'Complex-non-cyclic': '#FFBE00',
+    #     'Linear': '#1B6FB9'
+    # }
     fig = px.pie(class_counts, values='Classification', color=class_counts.index, names=class_counts.axes[0].tolist(),
-                 color_discrete_map= color_scale_map)
+                 color_discrete_map= fa_cmap)
     fig.update_layout(font = dict( size=12, color="black"),
                 width=400,
                 height=400,

--- a/caper/caper/views.py
+++ b/caper/caper/views.py
@@ -20,7 +20,7 @@ import os
 import shutil
 import caper.sample_plot as sample_plot
 import caper.StackedBarChart as stacked_bar
-import caper.classification as piechart
+import caper.project_pie_chart as piechart
 from django.core.files.storage import FileSystemStorage
 # from django.views.decorators.cache import cache_page
 # from zipfile import ZipFile
@@ -49,6 +49,15 @@ db_handle, mongo_client = get_db_handle('caper', os.environ['DB_URI'])
 collection_handle = get_collection_handle(db_handle,'projects')
 fs_handle = gridfs.GridFS(db_handle)
 
+# Site-wide focal amp color scheme
+fa_cmap = {
+                'ecDNA': "rgb(255, 0, 0)",
+                'BFB': 'rgb(0, 70, 46)',
+                'Complex non-cyclic': 'rgb(255, 190, 0)',
+                'Linear amplification': 'rgb(27, 111, 185)',
+                'Complex-non-cyclic': 'rgb(255, 190, 0)',
+                'Linear': 'rgb(27, 111, 185)'
+                }
 
 def get_date():
     today = datetime.datetime.now()
@@ -345,12 +354,12 @@ def project_page(request, project_name):
     t_sb = time.time()
     diff = t_sb - t_sa
     print(f"Iteratively build project dataframe from samples in {diff} seconds")
-    stackedbar_plot = stacked_bar.StackedBarChart(aggregate)
-    pie_chart = piechart.pie_chart(aggregate)
+    stackedbar_plot = stacked_bar.StackedBarChart(aggregate, fa_cmap)
+    pc_fig = piechart.pie_chart(aggregate, fa_cmap)
     t_f = time.time()
     diff = t_f - t_i
     print(f"Generated the project page from views.py in {diff} seconds")
-    return render(request, "pages/project.html", {'project': project, 'sample_data': sample_data, 'reference_genome': reference_genome, 'stackedbar_graph': stackedbar_plot, 'piechart': pie_chart})
+    return render(request, "pages/project.html", {'project': project, 'sample_data': sample_data, 'reference_genome': reference_genome, 'stackedbar_graph': stackedbar_plot, 'piechart': pc_fig})
     
 
 def project_download(request, project_name):

--- a/caper/templates/pages/index.html
+++ b/caper/templates/pages/index.html
@@ -144,8 +144,8 @@
                         <datalist id="ecDNAclassificationDefaults">
                             <option value="ecDNA">ecDNA</option>
                             <option value="linear amplification">linear amplification</option>
-                            <option value="BFB">breakage-fusion-bridge (BFB) </option>
-                            <option value="complex non-cyclic">complex non-cyclic </option>
+                            <option value="BFB">breakage-fusion-bridge (BFB)</option>
+                            <option value="complex non-cyclic">complex non-cyclic</option>
 
 
                         </datalist>

--- a/caper/templates/pages/project.html
+++ b/caper/templates/pages/project.html
@@ -52,9 +52,6 @@
     <div  style="margin:auto; border: 0.5px solid grey; padding: 0px">
         <span style="display:inline-block">{{ stackedbar_graph|safe }}</span> <span style="display:inline-block">{{ piechart|safe }}</span>
     </div>
-    <div class="col-md-9"; style="margin:auto">
-        <span>Click and drag near top of sample names to scroll horizontally</span>
-    </div>
 
 </div>
 <br>


### PR DESCRIPTION
Still supports old names, but AC version 0.5.0 will use Linear amplification -> Linear, Complex non-cyclic -> Complex-non-cyclic to eliminate spaces in classification names. Update provides support for both naming conventions. Tested on AC results from prior and upcoming versions of AC.