### PR TITLE
Issue 156 124

### DIFF
--- a/caper/caper/urls.py
+++ b/caper/caper/urls.py
@@ -61,6 +61,8 @@ urlpatterns += [
     path('class-search/', views.class_search_page, name='class_search_page'),
     path('admin-featured-projects/', views.admin_featured_projects, name='admin_featured_projects'),
     path('admin-stats/', views.admin_stats, name='admin_stats'),
+    path('admin-stats/download/user/',views.user_stats_download,name="user_stats_download"),
+    path('admin-stats/download/project/',views.project_stats_download,name="project_stats_download"),
     path('admin-version-details/', views.admin_version_details, name='admin_version_details'),
     path('admin-delete-project/', views.admin_delete_project, name='admin_delete_project'),
 

--- a/caper/caper/views.py
+++ b/caper/caper/views.py
@@ -56,6 +56,7 @@ import boto3
 import botocore
 from threading import Thread
 import os, fnmatch
+import uuid
 
 import time
 import math
@@ -1422,8 +1423,8 @@ def create_project(request):
         # file download
         request_file = request.FILES['document'] if 'document' in request.FILES else None
 
-        project = create_project_helper(form, user, request_file)
-        project_data_path = f"tmp/{project_name}"
+        project, tmp_id = create_project_helper(form, user, request_file)
+        project_data_path = f"tmp/{tmp_id}"
 
 
         if form.is_valid():
@@ -1474,6 +1475,7 @@ def create_project_helper(form, user, request_file, save = True):
     """
     form_dict = form_to_dict(form)
     project_name = form_dict['project_name']
+    tmp_id = uuid.uuid4().hex
     project = dict()        
     # download_file(project_name, form_dict['file'])
     # runs = samples_to_dict(form_dict['file'])
@@ -1481,7 +1483,7 @@ def create_project_helper(form, user, request_file, save = True):
     # file download
     
     if request_file:
-        project_data_path = f"tmp/{project_name}"
+        project_data_path = f"tmp/{tmp_id}"
         # create a new instance of FileSystemStorage
         if save:
             fs = FileSystemStorage(location=project_data_path)
@@ -1548,7 +1550,7 @@ def create_project_helper(form, user, request_file, save = True):
     project['runs'] = runs
     project['Oncogenes'] = get_project_oncogenes(runs)
     project['Classification'] = get_project_classifications(runs)
-    return project
+    return project, tmp_id
     
 
 class FileUploadView(APIView):

--- a/caper/templates/pages/admin_stats.html
+++ b/caper/templates/pages/admin_stats.html
@@ -80,6 +80,7 @@
     <div class="col-md-12">
         <div>
             <h1 style="padding-top: 50px">Projects</h1>
+            <a class="btn btn-primary" href="/admin-stats/download/project/" style="color: white">Download Project Stats</a>
 
 
             <hr>
@@ -113,7 +114,6 @@
         <div>
             <ul class="nav nav-tabs" role="tablist" >
                 <li class="nav-item">
-                
                     <a class="nav-link active" href="#tab-table0" data-toggle="tab">Public Projects</a>
                 </li>
 
@@ -173,6 +173,7 @@
         
         <div>
             <h1 style="padding-top:25px">Users</h1>
+            <a class="btn btn-primary" href="/admin-stats/download/user/" style="color: white">Download User Stats</a>
             <hr>
             <div class="tab-content" style="padding-top: 30px;">
 

--- a/caper/templates/pages/admin_stats.html
+++ b/caper/templates/pages/admin_stats.html
@@ -173,7 +173,7 @@
         
         <div>
             <h1 style="padding-top:25px">Users</h1>
-            <a class="btn btn-primary" href="/admin-stats/download/user/" style="color: white">Download User Stats</a>
+            <a class="btn btn-primary" href="/admin-stats/download/user/" style="color: white">Download User Data</a>
             <hr>
             <div class="tab-content" style="padding-top: 30px;">
 


### PR DESCRIPTION
This should fix issue 156 and 124.

The fixes include adding download buttons on the admin-stats page for downloading csv versions of the stats tables.

The bug in issue 124 is no longer showing with the use of temporary UUID instead of project name for folder creation.