### PR TITLE
plotly image downloads as svg

### DIFF
--- a/caper/caper/StackedBarChart.py
+++ b/caper/caper/StackedBarChart.py
@@ -69,6 +69,10 @@ def StackedBarChart(sample, fa_cmap):
 
     end_time = time.time()
     elapsed_time = end_time - start_time
+    updated_config_dict = {'displayModeBar': ['True'],
+                           'toImageButtonOptions': {
+                               'format': 'svg',  # one of png, svg, jpeg, webp
+                            }
+                           }
     logging.info(f"Created project barchart plot in {elapsed_time} seconds")
-    return fig.to_html(full_html=False, config={'displayModeBar': ['True']}, #'modeBarButtonsToRemove': ['zoom'],
-                       div_id="project_bar_plotly_div")
+    return fig.to_html(full_html=False, config=updated_config_dict, div_id="project_bar_plotly_div")

--- a/caper/caper/project_pie_chart.py
+++ b/caper/caper/project_pie_chart.py
@@ -34,5 +34,11 @@ def pie_chart(sample, fa_cmap):
     fig.update_traces(textfont_size = 12, textposition='inside', hovertemplate= '<b>%{label}</b><br>%{value} Focal Amps')
     fig.update_layout(margin={'t': 0, 'b': 40})
 
-    return fig.to_html(full_html=False, config={'displayModeBar': True, 'displaylogo':False}, div_id='project_pie_plotly_div')
+    updated_config_dict = {'displayModeBar': True, 'displaylogo':False,
+                           'toImageButtonOptions': {
+                               'format': 'svg',  # one of png, svg, jpeg, webp
+                            }
+                           }
+
+    return fig.to_html(full_html=False, config=updated_config_dict, div_id='project_pie_plotly_div')
     

--- a/caper/caper/sample_plot.py
+++ b/caper/caper/sample_plot.py
@@ -352,7 +352,13 @@ def plot(db_handle, sample, sample_name, project_name, filter_plots=False):
         end_time = time.time()
         elapsed_time = end_time - start_time
         logging.info(f"Created sample plot in {elapsed_time} seconds")
-        return fig.to_html(full_html=False, div_id='plotly_div')
+
+        updated_config_dict = {'toImageButtonOptions': {
+                                   'format': 'svg',  # one of png, svg, jpeg, webp
+                                }
+                               }
+
+        return fig.to_html(full_html=False, config=updated_config_dict, div_id='plotly_div')
 
     else:
         plot = go.Figure(go.Scatter(x=[2], y = [2],


### PR DESCRIPTION
All this does is change the plotly image download button to save the plotly images as .svg (vector format). If users want, they can always get a non-vector image (png) from screenshot. This change is much better for immediately getting publication-quality figures from the site.