### PR TITLE
disallow users to access edit page via /edit

### DIFF
--- a/caper/caper/views.py
+++ b/caper/caper/views.py
@@ -1298,6 +1298,12 @@ def edit_project_page(request, project_name):
             return HttpResponse("Project does not exist")
     else:
         project = get_one_project(project_name)
+        prev_versions, prev_ver_msg = previous_versions(project)
+        if prev_ver_msg:
+            messages.error(request, "Redirected to latest version, editing of old versions not allowed. ")
+            return redirect('project_page', project_name = prev_versions[0]['linkid'])
+            
+        print(prev_ver_msg)
         # split up the project members and remove the empties
         members = project['project_members']
         try:

--- a/caper/templates/pages/edit_project.html
+++ b/caper/templates/pages/edit_project.html
@@ -38,7 +38,7 @@
 </style>
 
 {% block main %}
-
+    
 <h1>Editing project: '{{ project.project_name }}'</h1>
 {% if alert_message %}
 <div class="alert alert-danger" role="alert">


### PR DESCRIPTION
if user tries to access the /edit/ page on a previous version, they'll get redirected to the latest project page with a banner at the top. 