### PR TITLE
Capthcha

### DIFF
--- a/caper/caper/forms.py
+++ b/caper/caper/forms.py
@@ -6,7 +6,7 @@ from .models import FeaturedProjectUpdate, AdminDeleteProject, AdminSendEmail, U
 from allauth.account.forms import SignupForm
 from allauth.socialaccount.forms import SignupForm as SocialSignupForm
 from django_recaptcha.widgets import ReCaptchaV2Checkbox
-
+from django_recaptcha.fields import ReCaptchaField
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit, Layout, Field
 

--- a/caper/caper/forms.py
+++ b/caper/caper/forms.py
@@ -5,6 +5,7 @@ from .models import Run
 from .models import FeaturedProjectUpdate, AdminDeleteProject, AdminSendEmail, UserPreferencesModel, UploadTarFile
 from allauth.account.forms import SignupForm
 from allauth.socialaccount.forms import SignupForm as SocialSignupForm
+from django_recaptcha.widgets import ReCaptchaV2Checkbox
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit, Layout, Field
@@ -105,7 +106,7 @@ class UserPreferencesForm(forms.ModelForm):
 
 
 class MySignUpForm(SignupForm):
-
+    captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox)
     def __init__(self, *args, **kwargs):
         super(MySignUpForm, self).__init__(*args, **kwargs)
 

--- a/caper/caper/settings.py
+++ b/caper/caper/settings.py
@@ -170,6 +170,9 @@ GOOGLE_SECRET_KEY = os.environ['GOOGLE_SECRET_KEY']
 GLOBUS_SECRET_KEY = os.environ['GLOBUS_SECRET_KEY']
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = os.getenv('ACCOUNT_DEFAULT_HTTP_PROTOCOL', default='https')
 
+RECAPTCHA_PRIVATE_KEY = os.environ['RECAPTCHA_PRIVATE_KEY']
+RECAPTCHA_PUBLIC_KEY =  os.environ['RECAPTCHA_PUBLIC_KEY']
+
 # add a custom account adaptor to prevent having a username match an email in another user
 # account
 ACCOUNT_ADAPTER = "caper.utils.CustomAccountAdapter"
@@ -348,6 +351,7 @@ INSTALLED_APPS = [
     "django.contrib.sites",
     "django.contrib.sitemaps",
     "django.contrib.messages",
+    "django_recaptcha",
     # "django_extensions",
     # "sslserver",
     "django.contrib.staticfiles",

--- a/caper/templates/account/signup.html
+++ b/caper/templates/account/signup.html
@@ -23,7 +23,7 @@
 
 <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
   {% csrf_token %}
-  {% crispy form %}
+ 
   {{ form.email|as_crispy_field }}
   {{ form.password1|as_crispy_field }}
   {{ form.password2|as_crispy_field }}

--- a/caper/templates/account/signup.html
+++ b/caper/templates/account/signup.html
@@ -9,19 +9,33 @@
 {% block main %}
 {% block content %}
 <h4>{% trans "Create new account" %}</h4>
-
+<style>
+#id_captcha {
+    color: #ffffff;
+    border: 0px white;
+    margin-bottom: 60px;
+}
+</style>
 <p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in here</a>.{% endblocktrans %}</p>
+
+
+
 
 <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
   {% csrf_token %}
-
-{% crispy form %}
+  {% crispy form %}
+  {{ form.email|as_crispy_field }}
+  {{ form.password1|as_crispy_field }}
+  {{ form.password2|as_crispy_field }}
+  {{ form.captcha|as_crispy_field }}
 
   {% if redirect_field_value %}
   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}
 
+  <button type="submit">{% trans "Sign up" %}</button>
 </form>
+
 
 {% endblock %}
 {% endblock %}

--- a/caper/templates/account/signup.html
+++ b/caper/templates/account/signup.html
@@ -23,7 +23,7 @@
 
 <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
   {% csrf_token %}
- 
+  {{ form.username|as_crispy_field }}
   {{ form.email|as_crispy_field }}
   {{ form.password1|as_crispy_field }}
   {{ form.password2|as_crispy_field }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ defusedxml==0.7.1
 Django==4.0.6
 django-allauth==0.51.0
 django-bootstrap4==22.2
+django-recaptcha==4.0.0
 django-contrib-comments==2.2.0
 django-crispy-forms==1.14.0
 djangorestframework==3.14.0


### PR DESCRIPTION
The recaptcha should show as a checkbox on the local account registration page.  Not done for the social account registration since its up to google (or whoever) to police those and I am not sure where it could go.

The necessary keys for this to work are in config.sh in both dev and prod already.  They are at the bottom of the file 
right after the comments that look like these 2 lines below...

# for recaptcha, using ampliconrepository@cloud.ucsd.edu in the google dev console
# https://www.google.com/u/3/recaptcha/admin/site/716296777
