### PR TITLE
Issue 307.  Place a banner across the top of the dev server

### DIFF
--- a/caper/caper/context_processor.py
+++ b/caper/caper/context_processor.py
@@ -6,3 +6,7 @@ def context_processor(request):
     return context   
 
 
+def server_identification_banner(request):
+    return {
+        'SERVER_IDENTIFICATION_BANNER': settings.SERVER_IDENTIFICATION_BANNER
+    }

--- a/caper/caper/settings.py
+++ b/caper/caper/settings.py
@@ -155,6 +155,10 @@ EMAIL_HOST_USER_SECRET = EMAIL_HOST_USER
 EMAIL_USE_TLS = True #new
 SITE_URL = os.environ.get("SITE_URL", default="http://127.0.0.1:8000/")
 
+SERVER_IDENTIFICATION_BANNER=os.getenv('SERVER_IDENTIFICATION_BANNER', default=None)
+
+logging.error(f"SERVER_IDENTIFICATION_BANNER: {SERVER_IDENTIFICATION_BANNER}")
+
 #ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS = os.environ['ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS']
 
 SECRET_KEY = 'c4nc3r'
@@ -324,7 +328,9 @@ TEMPLATES = [
                 "mezzanine.conf.context_processors.settings",
                 "mezzanine.pages.context_processors.page",
                 # 'caper.context_processors.get_files'
-                "caper.context_processor.context_processor"
+                "caper.context_processor.context_processor",
+                "caper.context_processor.server_identification_banner",
+
             ],
             "loaders": [
                 "mezzanine.template.loaders.host_themes.Loader",

--- a/caper/templates/includes/header.html
+++ b/caper/templates/includes/header.html
@@ -1,3 +1,10 @@
+{% if SERVER_IDENTIFICATION_BANNER %}
+<div style="width: 100%; background-color: yellow; text-align: center; padding: 10px;">
+    {{ SERVER_IDENTIFICATION_BANNER | safe }}
+</div>
+{% else %}
+
+{% endif %}
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
To add a banner, inlcude an environment variable in config.sh like so:

export SERVER_IDENTIFICATION_BANNER='your message in html'

There is an example of this added to config.sh in the dev server.  Leave it absent and nothing shows, this is how prod should be left, with this not set.  We could however use this mechanism on prod to add urgent announcements at some future point (though it would require a restart)