### PR TITLE
Issue 318 typo fix

### DIFF
--- a/caper/caper/views.py
+++ b/caper/caper/views.py
@@ -1754,7 +1754,7 @@ def edit_project_page(request, project_name):
 
                     if os.path.exists(temp_directory):
                         shutil.rmtree(temp_directory)
-                    alert_message = "Edit project failed. Please ensure all uploaded samples have the same reference genome and are valid AmplionSuite results."
+                    alert_message = "Edit project failed. Please ensure all uploaded samples have the same reference genome and are valid AmpliconSuite results."
 
                     return render(request, 'pages/edit_project.html',
                               {'project': project,
@@ -3447,7 +3447,7 @@ class ProjectFileAddView(APIView):
             agg = Aggregator(file_fps, temp_directory, tmp_project_data_path, 'No', "", 'python3', uuid=str(api_id))
             if not agg.completed:
                 ## redirect to edit page if aggregator fails
-                alert_message = "Edit project failed. Please ensure all uploaded samples have the same reference genome and are valid AmplionSuite results."
+                alert_message = "Edit project failed. Please ensure all uploaded samples have the same reference genome and are valid AmpliconSuite results."
             else:
                 with open(agg.aggregated_filename, 'rb') as f:
                     uploaded_file = SimpleUploadedFile(

--- a/caper/templates/pages/project.html
+++ b/caper/templates/pages/project.html
@@ -186,7 +186,7 @@
                  <div class="modal-body">
                    <div class="form-group row mb-2 col-form-label-sm">When running AmpliconSuite you can provide these values to have samples automatically added to this project.</div>
                    <div class="form-group row mb-2">
-                     <label for="projectUuid" class="col-sm-3 col-form-label col-form-label-sm">Project UUID:</label>
+                     <label for="projectUuid" class="col-sm-3 col-form-label col-form-label-sm">Project ID:</label>
                      <div class="col-sm-9">
                        <input type="text" class="form-control" id="projectUuid" value="{{ project.linkid }}" readonly>
                      </div>


### PR DESCRIPTION
fixing typos in the emails sent after api uploads succeed or fail.  Also renaming project uuid to just project id in the key dialog since its not technically a UUID after all.