### PR TITLE
email compatibility with python3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ For shutdown at the end of your session, you can do `sudo neo4j stop`
 
 ## 5. Set up secret keys for OAuth2 and other environment variables
 - Make sure you have the `config.sh` file from another developer (this contains secret key information)
-- Run the command to initialize variables:
-`source config.sh`
+- Run the command to initialize variables (from the top-level repo directory):
+`source caper/config.sh`
 
 For local deployments, you will need to ensure that the following two variables are set to FALSE, as shown below
 ```

--- a/caper/caper/email_backend.py
+++ b/caper/caper/email_backend.py
@@ -1,0 +1,45 @@
+import ssl
+
+from django.core.mail.backends.smtp import EmailBackend
+from django.core.mail.utils import DNS_NAME
+
+
+class SSLCompatEmailBackend(EmailBackend):
+    """
+    SMTP email backend compatible with Python 3.10 and 3.12+.
+
+    Django 4.0.x passes deprecated `keyfile` and `certfile` kwargs to
+    smtplib.SMTP.starttls(), which were removed in Python 3.12. This
+    backend replaces those with an ssl.SSLContext, which works on both.
+    """
+
+    def _make_ssl_context(self):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        if self.ssl_keyfile and self.ssl_certfile:
+            context.load_cert_chain(certfile=self.ssl_certfile, keyfile=self.ssl_keyfile)
+        return context
+
+    def open(self):
+        if self.connection:
+            return False
+
+        connection_params = {"local_hostname": DNS_NAME.get_fqdn()}
+        if self.timeout is not None:
+            connection_params["timeout"] = self.timeout
+        if self.use_ssl:
+            connection_params["context"] = self._make_ssl_context()
+
+        try:
+            self.connection = self.connection_class(self.host, self.port, **connection_params)
+            if not self.use_ssl and self.use_tls:
+                self.connection.ehlo()
+                self.connection.starttls(context=self._make_ssl_context())
+                self.connection.ehlo()
+            if self.username and self.password:
+                self.connection.login(self.username, self.password)
+            return True
+        except OSError:
+            if not self.fail_silently:
+                raise

--- a/caper/caper/settings.py
+++ b/caper/caper/settings.py
@@ -162,7 +162,7 @@ AUTHENTICATION_BACKENDS = [
 ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_EMAIL_REQUIRED = False
 
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_BACKEND = 'caper.email_backend.SSLCompatEmailBackend'
 #ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS = os.environ['ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS']
 
 EMAIL_HOST = 'smtp.gmail.com' #new

--- a/caper/caper/views.py
+++ b/caper/caper/views.py
@@ -3618,7 +3618,7 @@ def toggle_project_subscription(request, project_name):
     # Update the project with new subscribers list
     query = {'_id': project['_id']}
     new_val = {"$set": {'subscribers': subscribers}}
-    collection_handle.update_one(query, new_val)
+    collection_handle_primary.update_one(query, new_val)
 
     # Return the subscription status
     return JsonResponse({

--- a/caper/caper/views_apis.py
+++ b/caper/caper/views_apis.py
@@ -28,7 +28,7 @@ from .serializers import FileSerializer
 from .forms import RunForm
 from .utils import (
     collection_handle, get_one_project, form_to_dict,
-    get_latest_project_version, normalize_visibility_field
+    get_latest_project_version, normalize_visibility_field, is_project_private
 )
 from .extra_metadata import *
 
@@ -295,7 +295,6 @@ class ProjectFileAddView(APIView):
                     # project_delete already removed old project stats; restore them so the
                     # site statistics are not left in a permanently decremented state.
                     from .site_stats import add_project_to_site_statistics
-                    from .utils import normalize_visibility_field, is_project_private
                     try:
                         vis = normalize_visibility_field(project.get('private', 'private'))
                         add_project_to_site_statistics(project, is_project_private(vis))
@@ -313,7 +312,6 @@ class ProjectFileAddView(APIView):
                     # _create_project failed after project_delete already removed the old project's
                     # stats — restore them so the site statistics are not permanently wrong.
                     from .site_stats import add_project_to_site_statistics
-                    from .utils import normalize_visibility_field, is_project_private
                     try:
                         vis = normalize_visibility_field(project.get('private', 'private'))
                         add_project_to_site_statistics(project, is_project_private(vis))

--- a/caper/templates/pages/project.html
+++ b/caper/templates/pages/project.html
@@ -613,8 +613,21 @@
         selection.removeAllRanges();
     }
 
-
-
+    // Global CSRF helper — must be available to all users (not just editors)
+    function getCookie(name) {
+        let cookieValue = null;
+        if (document.cookie && document.cookie !== '') {
+            const cookies = document.cookie.split(';');
+            for (let i = 0; i < cookies.length; i++) {
+                const cookie = cookies[i].trim();
+                if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        return cookieValue;
+    }
 
 </script>
 


### PR DESCRIPTION
This introduces changes that should make the emailer work with python3.10 and onward. It will be good to test this in a 3.10 environment too.