### PR TITLE
 1. DataTable init (sample.html:7): Replaced the broken drawCallback …

### DIFF
--- a/caper/static/css/style.css
+++ b/caper/static/css/style.css
@@ -107,10 +107,9 @@ table.dataTable.no-border tbody td {
   border: 0;
 }
 
-/* Let DataTable content overflow to page level instead of creating in-div scrollbars */
-.dataTables_scroll,
-.dataTables_scrollBody {
-    overflow: visible !important;
+/* Let DataTable wrapper expand to table's minimum width so overflow reaches the page level */
+.dataTables_wrapper {
+    min-width: min-content;
 }
 
 @keyframes spin {

--- a/caper/static/css/style.css
+++ b/caper/static/css/style.css
@@ -107,6 +107,12 @@ table.dataTable.no-border tbody td {
   border: 0;
 }
 
+/* Let DataTable content overflow to page level instead of creating in-div scrollbars */
+.dataTables_scroll,
+.dataTables_scrollBody {
+    overflow: visible !important;
+}
+
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }

--- a/caper/templates/pages/sample.html
+++ b/caper/templates/pages/sample.html
@@ -4,7 +4,7 @@
 {% block extra_js %}
 <script>
     $(document).ready( function () {
-        $('#myTable2').DataTable();
+        $('#myTable2').DataTable({ autoWidth: false });
     } );
 </script>
 
@@ -304,7 +304,7 @@
 {% endif %}
 
 
-<div style="margin-top:25px; padding: 25px; border: 0.5px solid grey;">
+<div style="margin-top:25px; padding: 25px; border: 0.5px solid grey; min-width: min-content;">
     <table id='myTable2' class="table table-hover table-sm stripe no-border">
         <thead>
             <tr>

--- a/caper/templates/pages/sample.html
+++ b/caper/templates/pages/sample.html
@@ -5,11 +5,8 @@
 <script>
     $(document).ready( function () {
         $('#myTable2').DataTable({
-            "drawCallback": function( settings ) {
-                $("#usersTable").wrap( "<div class='table-responsive'></div>" );
-            }
-        }
-        );
+            scrollX: true
+        });
     } );
 </script>
 
@@ -309,8 +306,8 @@
 {% endif %}
 
 
-<div style="margin-top:25px; padding: 25px; border: 0.5px solid grey; overflow-x: auto;">
-    <table id='myTable2' class="table table-hover table-sm stripe no-border" style="min-width: 600px;">
+<div style="margin-top:25px; padding: 25px; border: 0.5px solid grey;">
+    <table id='myTable2' class="table table-hover table-sm stripe no-border">
         <thead>
             <tr>
                 <th>Amplicon</th>

--- a/caper/templates/pages/sample.html
+++ b/caper/templates/pages/sample.html
@@ -4,9 +4,7 @@
 {% block extra_js %}
 <script>
     $(document).ready( function () {
-        $('#myTable2').DataTable({
-            scrollX: true
-        });
+        $('#myTable2').DataTable();
     } );
 </script>
 

--- a/caper/templates/pages/sample.html
+++ b/caper/templates/pages/sample.html
@@ -312,14 +312,14 @@
                 <th>Feature ID</th>
                 <th>Classification</th>
                 <th>Oncogenes</th>
-                <th>
+                <th style="white-space: nowrap">
                     Context
                     <span class="info-tooltip" data-toggle="tooltip" data-placement="top"
                           title="Annotation for ecDNA type based on patterns in SV and CN profiles.">
                         <i class="fas fa-question-circle" style="font-size: 0.9em; color: #6c757d; cursor: help;"></i>
                     </span>
                 </th>
-                <th>
+                <th style="white-space: nowrap">
                     Location
                     <span class="info-tooltip" data-toggle="tooltip" data-placement="top"
                           title="Genomic coordinates this feature captures. Not representative of amplification structure.">


### PR DESCRIPTION
…(which was targeting #usersTable, a non-existent ID) with scrollX: true. This makes DataTable manage its own horizontal scroll wrapper correctly.

  2. Outer container (sample.html:312): Removed overflow-x: auto. This was the root cause — CSS spec requires that when overflow-x is set to anything other than visible, overflow-y is also promoted to auto. When the table triggered a horizontal scrollbar, that scrollbar consumed height and caused a secondary vertical scrollbar.